### PR TITLE
Added tests. Added Python3 compatibility.

### DIFF
--- a/argconfparse/argconfparse.py
+++ b/argconfparse/argconfparse.py
@@ -1,7 +1,16 @@
 """argconfparse.py: ArgumentParser with ConfigParser thrown in."""
 
+from __future__ import print_function
+
+try:
+    from ConfigParser import SafeConfigParser as ConfigParser
+except ImportError:
+    try:
+        from configparser import SafeConfigParser as ConfigParser
+    except ImportError:
+        from configparser import ConfigParser
 import argparse
-import ConfigParser
+from codecs import decode
 
 
 __author__ = "Raido Pahtma"
@@ -31,16 +40,16 @@ class ConfigArgumentParser(object):
         args, remaining_argv = self.conf_parser.parse_known_args()
 
         if args.conf_file:
-            config = ConfigParser.SafeConfigParser()
+            config = ConfigParser()
 
             if len(config.read([args.conf_file])) > 0:
 
                 if config.has_section("defaults"):
-                    for key, value in dict(config.items("defaults")).iteritems():
+                    for key, value in dict(config.items("defaults")).items():
                         args, unknown = self.parser.parse_known_args(("--{}".format(key), value), namespace=args)
 
                 if config.has_section(self.section):
-                    for key, value in dict(config.items(self.section)).iteritems():
+                    for key, value in dict(config.items(self.section)).items():
                         args, unknown = self.parser.parse_known_args(("--{}".format(key), value), namespace=args)
                         if len(unknown) > 0:
                             if key.startswith("var_") is False:
@@ -72,8 +81,11 @@ def arg_check_hex16str(v):
     """ Verify that the provided argument is a 16 character hexadecimal string """
     if isinstance(v, str):
         if len(v) == 16:
-            v.decode("hex")
-            return v
+            try:
+                decode(v, "hex")
+                return v
+            except TypeError:
+                raise ValueError("Value must be a valid HEX string")
         else:
             raise ValueError("Value must be 16 characters long")
     raise ValueError("Value must be a string")
@@ -86,4 +98,4 @@ if __name__ == '__main__':
     parser.add_argument("--option2", help="some other option")
     parser.add_argument("--option3", help="some third option")
 
-    print parser.parse_args()
+    print(parser.parse_args())

--- a/argconfparse/tests/sample.conf
+++ b/argconfparse/tests/sample.conf
@@ -1,0 +1,4 @@
+[sample]
+argument1 = 0123456789ABCDEF
+argument2 = 0xFF
+argument3 = t

--- a/argconfparse/tests/test_config.py
+++ b/argconfparse/tests/test_config.py
@@ -1,0 +1,36 @@
+from unittest import TestCase
+import os
+
+from mock import patch
+
+from argconfparse import argconfparse
+
+
+class ConfigFileTester(TestCase):
+    CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sample.conf")
+
+    def setUp(self):
+        self.parser = argconfparse.ConfigArgumentParser(
+            "sample",
+            description="ConfigArgumentParser test description."
+        )
+        self.parser.add_argument("--argument1", help="some option")
+        self.parser.add_argument("--argument2", help="some other option")
+        self.parser.add_argument("--argument3", help="some third option")
+
+    def tearDown(self):
+        del self.parser
+
+    def test_config(self):
+        argv = [
+            "program_name",
+            "-c", ConfigFileTester.CONFIG_FILE,
+            "--argument1", "NOT 0123456789ABCDEF"
+        ]
+        with patch.object(argconfparse.argparse._sys, 'argv', argv):
+            args = self.parser.parse_args()
+            # precedence works
+            self.assertEqual(args.argument1, 'NOT 0123456789ABCDEF')
+            # conf file values work
+            self.assertEqual(args.argument2, '0xFF')
+            self.assertEqual(args.argument3, 't')

--- a/argconfparse/tests/test_helper_functions.py
+++ b/argconfparse/tests/test_helper_functions.py
@@ -1,0 +1,95 @@
+from unittest import TestCase
+import os
+
+from mock import patch
+
+from argconfparse import argconfparse
+
+
+class TypeConversionTester(TestCase):
+    CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sample.conf")
+
+    def setUp(self):
+        self.parser = argconfparse.ConfigArgumentParser(
+            "sample",
+            description="ConfigArgumentParser test description."
+        )
+        self.parser.add_argument(
+            "--argument1",
+            type=argconfparse.arg_check_hex16str,
+            help="some option"
+        )
+        self.parser.add_argument(
+            "--argument2",
+            type=argconfparse.arg_hex2int,
+            help="some other option"
+        )
+        self.parser.add_argument(
+            "--argument3",
+            type=argconfparse.arg_str2bool,
+            help="some third option"
+        )
+
+    def tearDown(self):
+        del self.parser
+
+    def test_config_type_conversion(self):
+        argv = [
+            "program_name",
+            "-c", TypeConversionTester.CONFIG_FILE,
+        ]
+        with patch.object(argconfparse.argparse._sys, 'argv', argv):
+            args = self.parser.parse_args()
+            self.assertEqual(args.argument1, '0123456789ABCDEF')
+            self.assertEqual(args.argument2, 0xFF)
+            self.assertEqual(args.argument3, True)
+
+    def test_cmdline_type_conversion(self):
+        argv = [
+            "program_name",
+            "-c", TypeConversionTester.CONFIG_FILE,
+            "--argument1", "0011223344556677",
+            "--argument2", "0x44",
+            "--argument3", "f"
+        ]
+        with patch.object(argconfparse.argparse._sys, 'argv', argv):
+            args = self.parser.parse_args()
+            self.assertEqual(args.argument1, '0011223344556677')
+            self.assertEqual(args.argument2, 0x44)
+            self.assertFalse(args.argument3)
+            self.assertIsInstance(args.argument3, bool)
+
+
+class ConversionFunctionTester(TestCase):
+    def test_check_hex16str(self):
+        func = argconfparse.arg_check_hex16str
+        self.assertRaises(ValueError, func, 'not a hex string')
+        parsed = func('0123456789ABCDEF')
+        self.assertEqual(parsed, '0123456789ABCDEF')
+
+    def test_hex2str(self):
+        func = argconfparse.arg_hex2int
+        self.assertRaises(ValueError, func, 'not a number')
+        parsed = func('0b10')
+        self.assertIsInstance(parsed, int)
+        self.assertEqual(parsed, 2)
+        parsed = func('0x10')
+        self.assertIsInstance(parsed, int)
+        self.assertEqual(parsed, 16)
+        parsed = func('10')
+        self.assertIsInstance(parsed, int)
+        self.assertEqual(parsed, 10)
+
+    def test_str2bool(self):
+        tests = [
+            ('value', self.assertFalse),
+            ('T', self.assertTrue),
+            ('t', self.assertTrue),
+            ('true', self.assertTrue),
+            ('1', self.assertTrue),
+            ('2', self.assertFalse),        # TODO: Should this be correct?
+        ]
+        for value, test_func in tests:
+            parsed = argconfparse.arg_str2bool(value)
+            self.assertIsInstance(parsed, bool)
+            test_func(parsed)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 doclines = __doc__.split("\n")
 
 setup(name='argconfparse',
-      version='0.1.1',
+      version='0.1.2.dev0',
       description='Python argparse with options to read argument values from configuration files.',
       long_description='\n'.join(doclines[2:]),
       url='http://github.com/proactivity-lab/python-argconfparse',
@@ -18,4 +18,5 @@ setup(name='argconfparse',
       license='MIT',
       platforms=["any"],
       packages=['argconfparse'],
+      tests_require=['mock', 'nose'],
       zip_safe=False)


### PR DESCRIPTION
All tests pass on Python 2.7.13 and Python 3.6.1

I had to add the `mock` library as a test requirement due to it being unavailable in the standard `unittest` before Python 3.0. The `nose` test dependency was also added.

Any suggestions on improving test coverage can be addressed before the pull request is finalized. I also bumped up the version number by a minor unit.